### PR TITLE
style sponsors page

### DIFF
--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -1,4 +1,4 @@
-@import "~bulma/sass/utilities/initial-variables"
+@import "~bulma"
 
 // Config vars
 // Kalidi logo brand color: #FD461E
@@ -31,6 +31,29 @@ $body-color: #333
     margin-bottom: 1.5rem
     margin-top: 0
 
+.sponsor-level-container
+  align-items: flex-start
+  display: flex
+  flex-flow: row wrap
+  justify-content: center
+
+  .card
+    margin: 1rem
+    max-width: 25rem
+    width: auto
+
+    // bad but the gatsby wrapper doesn't play nice
+    .card-image *
+      display: block !important
+      margin: 0 auto
+
+    .card-header
+      justify-content: center
+
+      .card-header-title
+        flex-grow: initial
+        margin-bottom: initial
+
 // Helper Classes
 .full-width-image-container
   width: 100vw
@@ -48,7 +71,17 @@ $body-color: #333
 .margin-top-0
   margin-top: 0 !important
 
-@import "~bulma"
-
 .section
   padding: 0.5rem
+
+@media screen and (max-width: 700px)
+  .sponsor-level-container
+    .card
+      margin: 1rem 0
+      max-width: 100%
+
+      .card-content
+        word-break: break-word
+
+      .card-footer
+        flex-flow: row wrap

--- a/src/pages/sponsors/index.js
+++ b/src/pages/sponsors/index.js
@@ -22,15 +22,25 @@ export default class SponsorsPage extends React.Component {
                   key={level.id}
                 >
                 <h2>{level.name}</h2>
-                {level.sponsors.map((sponsor, index) => (
-                  <div>
-                    <h3>{sponsor.name}</h3>
-                    <Img fixed={sponsor.web_logo.local.childImageSharp.fixed}  alt={sponsor.web_logo.description}/>
-                    <p>{sponsor.url}</p>
-                    {sponsor.twitter && <p>@{sponsor.twitter}</p>}
-                    <p>{sponsor.description}</p>
-                  </div>
-                ))}
+                <div className="sponsor-level-container">
+                  {level.sponsors.map((sponsor, index) => (
+                    <div className="card" key={index}>
+                      <div className="card-image">
+                        <Img fixed={sponsor.web_logo.local.childImageSharp.fixed}  alt={sponsor.web_logo.description}/>
+                      </div>
+                      <div className="card-header">
+                        <h3 className="card-header-title">{sponsor.name}</h3>
+                      </div>
+                      <div className="card-content">
+                        <p>{sponsor.description}</p>
+                      </div>
+                      <div className="card-footer">
+                        <a href={sponsor.url} className="card-footer-item" aria-label={`Website for ${sponsor.name}`}>Website</a>
+                        {sponsor.twitter && <a href="https://twitter.com/{sponsor.twitter}" className="card-footer-item" aria-label={`@${sponsor.twitter} on Twitter`}>@{sponsor.twitter}</a>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
                 </div>
               ))}
           </div>


### PR DESCRIPTION
Closes #16 

Uses the [card](https://bulma.io/documentation/components/card/) component to encapsulate each sponsor.  Tiers are their own groups.  Set up using flexbox; will flow out from the center.  May look jank on actual tablets (I can only emulate) so we can adjust that as needed/desired.

Screenshots:
<img width="1187" alt="sponsors desktop" src="https://user-images.githubusercontent.com/5710080/56166939-ce2f6a80-5fa4-11e9-89b0-535e86fabe76.png">
<img width="322" alt="sponsors phone" src="https://user-images.githubusercontent.com/5710080/56166940-cec80100-5fa4-11e9-8737-39c3c0e0c13c.png">
