### PR TITLE
add spacing to sponsor logos

### DIFF
--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -81,7 +81,7 @@ ul
       flex-flow: column
       height: 250px
       justify-content: center
-      margin: auto
+      margin: 1rem auto
       width: 250px
 
       *
@@ -101,6 +101,9 @@ ul
   display: flex
   flex-flow: row wrap
   justify-content: center
+
+  .sponsor
+    margin: 1rem
 
 // Helper Classes
 .full-width-image-container


### PR DESCRIPTION
Adds margin on the homepage and sponsors listing.

Images:
![homepage logos small](https://user-images.githubusercontent.com/5710080/57454681-697bce80-7237-11e9-87d5-dd4fdd0a9fbd.png)
![homepage logos wide](https://user-images.githubusercontent.com/5710080/57454682-6a146500-7237-11e9-8766-a94b9e71c8dd.png)
![logo in card](https://user-images.githubusercontent.com/5710080/57454683-6a146500-7237-11e9-9f81-e594057769de.png)
