### PR TITLE
Nest schedule slots into time spans

### DIFF
--- a/src/components/ScheduleSlot.js
+++ b/src/components/ScheduleSlot.js
@@ -22,7 +22,7 @@ export default class ScheduleSlot extends React.Component {
     }
 
     return (
-      <div className="card schedule-item">
+      <div className={`card schedule-item ${this.slot.kind === 'talk' ? 'schedule-talk' : 'schedule-non-talk'}`}>
         <div className="card-content is-flex">
           <div className="schedule-item-wrapper">
             <h3 className="schedule-title">{this.slot.title}</h3>

--- a/src/components/ScheduleSlot.js
+++ b/src/components/ScheduleSlot.js
@@ -24,7 +24,7 @@ export default class ScheduleSlot extends React.Component {
     return (
       <div className="card schedule-item">
         <div className="card-content is-flex">
-          <div className="time-wrapper">
+          {/* <div className="time-wrapper">
             <p>
               <time>{formatTime(this.slot.start)}</time>
             </p>
@@ -34,10 +34,10 @@ export default class ScheduleSlot extends React.Component {
             <p>
               <time>{formatTime(this.slot.end)}</time>
             </p>
-          </div>
+          </div> */}
           <div className="schedule-item-wrapper">
-            <h3 className="is-size-3">{this.slot.title}</h3>
-            <p className="is-size-4">{this.slot.speaker_name}</p>
+            <h3 className="schedule-title">{this.slot.title}</h3>
+            <p className="schedule-speaker">{this.slot.speaker_name}</p>
             <p>{ this.slot.kind === 'break' || this.slot.title.includes('Registration') ? '' : `Room: ${this.slot.room}`}</p>
             <p>
                 {this.slot.presentation_id && (

--- a/src/components/ScheduleSlot.js
+++ b/src/components/ScheduleSlot.js
@@ -24,17 +24,6 @@ export default class ScheduleSlot extends React.Component {
     return (
       <div className="card schedule-item">
         <div className="card-content is-flex">
-          {/* <div className="time-wrapper">
-            <p>
-              <time>{formatTime(this.slot.start)}</time>
-            </p>
-            <p>
-              to
-            </p>
-            <p>
-              <time>{formatTime(this.slot.end)}</time>
-            </p>
-          </div> */}
           <div className="schedule-item-wrapper">
             <h3 className="schedule-title">{this.slot.title}</h3>
             <p className="schedule-speaker">{this.slot.speaker_name}</p>

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -184,8 +184,6 @@ article.speaker-bio
     margin-right: .75rem !important
     padding-top: .5em
     min-width: 7ch
-    position: sticky
-    top: 1em
 
     p:first-child time
       font-weight: bold
@@ -195,6 +193,12 @@ article.speaker-bio
     border-left: 2px solid $pyohio-red
     border-radius: 5px
     padding-left: 5px
+
+@media screen and (max-width: 700px)
+  .time-block
+    .time-wrapper
+      position: sticky
+      top: 1em
 
 .schedule-item
   flex-grow: 1

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -198,7 +198,12 @@ article.speaker-bio
   flex-grow: 1
   margin: .5rem
   min-width: 16em
+
+.schedule-talk
   max-width: 16em
+
+.schedule-non-talk
+  max-width: 24em
   
   .schedule-item-wrapper
 

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -177,13 +177,15 @@ article.speaker-bio
 .time-block
   flex-flow: row
   justify-content: flex-start
+  align-items: flex-start
   margin-bottom: 2rem
 
   .time-wrapper
     margin-right: .75rem !important
     padding-top: .5em
     min-width: 7ch
-    vertical-align: middle
+    position: sticky
+    top: 1em
 
     p:first-child time
       font-weight: bold

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -175,15 +175,25 @@ article.speaker-bio
   padding: .05rem
 
 .time-block
-  flex-flow: wrap
+  flex-flow: row
   justify-content: flex-start
   margin-bottom: 2rem
   margin-left: 1rem
   margin-right: 1rem
 
+  .time-block-label
+    min-width: 16ch
+
+  .time-block-slots
+    flex-flow: wrap
+    border-left: 2px solid $pyohio-red
+    border-radius: 5px
+    padding-left: 5px
+
 .schedule-item
   flex-grow: 1
-  margin: 1rem
+  margin: .5rem
+  min-width: 16em
   max-width: 16em
   
   .time-wrapper
@@ -194,11 +204,6 @@ article.speaker-bio
       font-weight: bold
 
   .schedule-item-wrapper
-    border-left: 2px solid $pyohio-red
-    border-radius: 5px
-    padding-left: 5px
-
-    
 
 // hideous, but it gets the job done
 .day:last-of-type .section:last-of-type .time-block:last-of-type

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -197,8 +197,8 @@ article.speaker-bio
 .schedule-item
   flex-grow: 1
   margin: .5rem
-  min-width: 15em
-  max-width: 15em
+  min-width: 16em
+  max-width: 16em
   
   .schedule-item-wrapper
 

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -172,7 +172,7 @@ article.speaker-bio
 
 // schedule
 .table-of-contents
-  padding: 1rem
+  padding: .05rem
 
 .time-block
   flex-flow: wrap
@@ -184,7 +184,8 @@ article.speaker-bio
 .schedule-item
   flex-grow: 1
   margin: 1rem
-
+  max-width: 16em
+  
   .time-wrapper
     margin-right: .75rem !important
     min-width: 8ch
@@ -195,11 +196,20 @@ article.speaker-bio
   .schedule-item-wrapper
     border-left: 2px solid $pyohio-red
     border-radius: 5px
-    padding-left: 10px
+    padding-left: 5px
+
+    
 
 // hideous, but it gets the job done
 .day:last-of-type .section:last-of-type .time-block:last-of-type
   margin-bottom: initial
+
+.schedule-title
+  font-size: 1em
+  font-weight: bold
+
+.schedule-speaker
+  font-size: 1em
 
 
 // Helper Classes

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -178,11 +178,15 @@ article.speaker-bio
   flex-flow: row
   justify-content: flex-start
   margin-bottom: 2rem
-  margin-left: 1rem
-  margin-right: 1rem
 
-  .time-block-label
-    min-width: 16ch
+  .time-wrapper
+    margin-right: .75rem !important
+    padding-top: .5em
+    min-width: 7ch
+    vertical-align: middle
+
+    p:first-child time
+      font-weight: bold
 
   .time-block-slots
     flex-flow: wrap
@@ -193,16 +197,9 @@ article.speaker-bio
 .schedule-item
   flex-grow: 1
   margin: .5rem
-  min-width: 16em
-  max-width: 16em
+  min-width: 15em
+  max-width: 15em
   
-  .time-wrapper
-    margin-right: .75rem !important
-    min-width: 8ch
-
-    p:first-child time
-      font-weight: bold
-
   .schedule-item-wrapper
 
 // hideous, but it gets the job done
@@ -210,11 +207,11 @@ article.speaker-bio
   margin-bottom: initial
 
 .schedule-title
-  font-size: 1em
+  font-size: 1.2rem
   font-weight: bold
 
 .schedule-speaker
-  font-size: 1em
+  font-size: 1.2rem
 
 
 // Helper Classes

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -194,7 +194,7 @@ article.speaker-bio
     border-radius: 5px
     padding-left: 5px
 
-@media screen and (max-width: 700px)
+@media screen and (max-width: 1080px)
   .time-block
     .time-wrapper
       position: sticky

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -209,9 +209,6 @@ article.speaker-bio
   max-width: 16em
 
 .schedule-non-talk
-  max-width: 24em
-  
-  .schedule-item-wrapper
 
 // hideous, but it gets the job done
 .day:last-of-type .section:last-of-type .time-block:last-of-type

--- a/src/templates/schedule-page.js
+++ b/src/templates/schedule-page.js
@@ -72,6 +72,7 @@ export default class SlottedSchedule extends React.Component {
                 <div className="section" key={section}>
                   {Object.entries(_.groupBy(slots, "start")).map(([start, slots]) => (
                     <div className="time-block is-flex" key={start}>
+                      <p>Time to Time</p>
                       {slots.map((slot) => (
                         <ScheduleSlot slot={slot} key={slot.id}/>
                       ))}

--- a/src/templates/schedule-page.js
+++ b/src/templates/schedule-page.js
@@ -72,10 +72,14 @@ export default class SlottedSchedule extends React.Component {
                 <div className="section" key={section}>
                   {Object.entries(_.groupBy(slots, "start")).map(([start, slots]) => (
                     <div className="time-block is-flex" key={start}>
+                      <div className="time-block-label">
                       <p>Time to Time</p>
+                      </div>
+                      <div className="time-block-slots is-flex">
                       {slots.map((slot) => (
                         <ScheduleSlot slot={slot} key={slot.id}/>
                       ))}
+                      </div>
                     </div>
                   ))}
                 </div>

--- a/src/templates/schedule-page.js
+++ b/src/templates/schedule-page.js
@@ -18,6 +18,7 @@ export default class SlottedSchedule extends React.Component {
       return dateOnly
     }
     slots.map(slot => slot.day = dateFromTimestamp(slot.start) )
+    slots.map(slot => slot.span = `${slot.start}-${slot.end}`)
     const daySlots = _.groupBy(slots, "day")
 
     // TODO: refactor this! Move to a utility (component?) file and use from there
@@ -32,6 +33,9 @@ export default class SlottedSchedule extends React.Component {
 
     function formatDate(timeString) {
       return formatDatetime(timeString, "%A, %B %d")
+    }
+    function formatTime(timeString) {
+      return formatDatetime(timeString, "%-I:%M%P")
     }
 
     function stringToID(timeString) {
@@ -70,10 +74,16 @@ export default class SlottedSchedule extends React.Component {
                 <h2 className="is-size-2">{formatDate(date)}</h2>
                 {Object.entries(_.groupBy(slots, "section")).sort().reverse().map(([section, slots]) => (
                 <div className="section" key={section}>
-                  {Object.entries(_.groupBy(slots, "start")).map(([start, slots]) => (
-                    <div className="time-block is-flex" key={start}>
-                      <div className="time-block-label">
-                      <p>Time to Time</p>
+                  {Object.entries(_.groupBy(slots, "span")).map(([span, slots]) => (
+                    <div className="time-block is-flex" key={span}>
+                      <div className="time-wrapper">
+                      <p>
+                        <time>{formatTime(slots[0].start)}</time>
+                      </p>
+                      <p>to</p>
+                      <p>
+                        <time>{formatTime(slots[0].end)}</time>
+                      </p>
                       </div>
                       <div className="time-block-slots is-flex">
                       {slots.map((slot) => (


### PR DESCRIPTION
* Adds group by time span so sessions w/ same start and end are shown on the same row
* Moves time and the red border to display only once per time span
* Adds all session slots w/ the same time span into div w/ `flex-flow: wrap`
* Makes time label sticky on lower resolution screens where having to scroll past the time is likely
* Constrains talk slots so they can display 4-wide on a decent full screen desktop

This _should_ cause the page to show four sessions wide on a majority of full screen desktop browsers while still being reasonable on mobile. Will test on multiple devices w/ PR.