### PR TITLE
Various styling fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "0.1.0",
   "author": "PyOhio",
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.19",
+    "@fortawesome/free-brands-svg-icons": "^5.9.0",
+    "@fortawesome/free-solid-svg-icons": "^5.9.0",
+    "@fortawesome/react-fontawesome": "^0.1.4",
     "bulma": "^0.7.4",
     "gatsby": "^2.0.66",
     "gatsby-image": "^2.0.23",

--- a/src/components/ScheduleSlot.js
+++ b/src/components/ScheduleSlot.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { Link } from "gatsby"
-import strftime from "strftime"
 
 export default class ScheduleSlot extends React.Component {
   constructor(props) {
@@ -8,19 +7,6 @@ export default class ScheduleSlot extends React.Component {
     this.slot = props.slot;
   }
   render() {
-    function formatDatetime(timeString, format) {
-      let formatted = ""
-      const datetime = new Date(timeString)
-      if (!isNaN(datetime)) {
-        formatted = strftime(format, datetime)
-      }
-      return formatted
-    }
-
-    function formatTime(timeString) {
-      return formatDatetime(timeString, "%-I:%M%P")
-    }
-
     return (
       <div className={`card schedule-item ${this.slot.kind === 'talk' ? 'schedule-talk' : 'schedule-non-talk'}`}>
         <div className="card-content is-flex">

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -170,6 +170,16 @@ article.speaker-bio
 .twitter-link
   font-size: initial
 
+.social-icons
+  margin-bottom: .5rem
+
+  ul
+    list-style: none
+    margin: 0
+
+    li
+      margin: .25rem
+
 // schedule
 .table-of-contents
   padding: .05rem
@@ -216,7 +226,6 @@ article.speaker-bio
 
 .schedule-speaker
   font-size: 1.2rem
-
 
 // Helper Classes
 .full-width-image-container

--- a/src/components/all.sass
+++ b/src/components/all.sass
@@ -193,6 +193,7 @@ article.speaker-bio
     border-left: 2px solid $pyohio-red
     border-radius: 5px
     padding-left: 5px
+    width: 100%
 
 @media screen and (max-width: 1080px)
   .time-block
@@ -203,12 +204,7 @@ article.speaker-bio
 .schedule-item
   flex-grow: 1
   margin: .5rem
-  min-width: 16em
-
-.schedule-talk
-  max-width: 16em
-
-.schedule-non-talk
+  max-width: 16rem
 
 // hideous, but it gets the job done
 .day:last-of-type .section:last-of-type .time-block:last-of-type

--- a/src/templates/speaker-page.js
+++ b/src/templates/speaker-page.js
@@ -3,17 +3,22 @@ import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 import { graphql, Link } from 'gatsby'
 import Img from "gatsby-image"
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTwitter, faMastodon } from '@fortawesome/free-brands-svg-icons'
+import { faCode } from '@fortawesome/free-solid-svg-icons'
 import Layout from '../components/Layout'
 import Content, { HTMLContent } from '../components/Content'
 
-export const SpeakerPageTemplate = ({ 
+export const SpeakerPageTemplate = ({
   contentComponent,
   photoSrc,
   presentations,
   speakerName,
   speakerBio,
   helmet,
-  twitter
+  twitter,
+  mastodon,
+  website
 }) => {
   const PageContent = contentComponent || Content
 
@@ -30,12 +35,42 @@ export const SpeakerPageTemplate = ({
           <div className="column is-10 is-offset-1">
             <div className="section speaker-bio">
               <h1 className="title is-size-2 has-text-weight-bold is-bold-light">
-                <span>Speaker: {speakerName} </span>
-                <span className="twitter-link">
-                  {(twitter) &&
-                  <a href={`https://twitter.com/${twitter}`}>@{twitter}</a>}
-                </span>
+                Speaker: {speakerName}
               </h1>
+              <div className="social-icons">
+                <ul>
+                  {(twitter) &&
+                    <li>
+                      <a href={`https://twitter.com/${twitter}`}>
+                        <span className="icon" role="presentation">
+                          <FontAwesomeIcon icon={faTwitter}/>&nbsp;
+                        </span>
+                        @{twitter}
+                        </a>
+                    </li>
+                  }
+                  {(mastodon) &&
+                    <li>
+                      <a href={mastodon}>
+                        <span className="icon" role="presentation">
+                          <FontAwesomeIcon icon={faMastodon}/>&nbsp;
+                        </span>
+                        {mastodon}
+                      </a>
+                    </li>
+                  }
+                  {(website) &&
+                  <li>
+                    <a href={website}>
+                      <span className="icon" role="presentation">
+                        <FontAwesomeIcon icon={faCode}/>&nbsp;
+                      </span>
+                      {website}
+                    </a>
+                  </li>
+                  }
+                </ul>
+              </div>
               <Img fixed={photoSrc}  alt={speakerName} className="speaker-image-wrapper is-clearfix"/>
               <PageContent className="content" content={speakerBio} />
               <h2 className="is-size-3">Presenting:</h2>
@@ -80,6 +115,8 @@ const SpeakerPage = ({ data }) => {
         speakerBio={speaker.biography_html}
         title={`Speaker: ${speaker.name}`}
         twitter={speaker.twitter}
+        mastodon={speaker.mastodon}
+        website={speaker.website}
         helmet={
           <Helmet>
             <title>{pageTitle}</title>
@@ -120,6 +157,8 @@ export const speakerPageQuery = graphql`
         presentation_id
       }
       twitter
+      mastodon
+      website
     }
   }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,6 +1040,40 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
   integrity sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==
 
+"@fortawesome/fontawesome-common-types@^0.2.19":
+  version "0.2.19"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.19.tgz#754a0f85e1290858152e1c05700ab502b11197f1"
+  integrity sha512-nd2Ul/CUs8U9sjofQYAALzOGpgkVJQgEhIJnOHaoyVR/LeC3x2mVg4eB910a4kS6WgLPebAY0M2fApEI497raQ==
+
+"@fortawesome/fontawesome-svg-core@^1.2.19":
+  version "1.2.19"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.19.tgz#0eca1ce9285c3d99e6e340633ee8f615f9d1a2e0"
+  integrity sha512-D4ICXg9oU08eF9o7Or392gPpjmwwgJu8ecCFusthbID95CLVXOgIyd4mOKD9Nud5Ckz+Ty59pqkNtThDKR0erA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.19"
+
+"@fortawesome/free-brands-svg-icons@^5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.9.0.tgz#4ebedba0ea026368f8c21f2c598b4458c32236e5"
+  integrity sha512-sOz1wFyslaHUak8tY6IEhSAV1mAWbCLssBR8yFQV6f065k8nUCkjyrcxW4RVl9+wiLXmeG1CJUABUJV9DiW+7Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.19"
+
+"@fortawesome/free-solid-svg-icons@^5.9.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.9.0.tgz#1c73e7bac17417d23f934d83f7fff5b100a7fda9"
+  integrity sha512-U8YXPfWcSozsCW0psCtlRGKjjRs5+Am5JJwLOUmVHFZbIEWzaz4YbP84EoPwUsVmSAKrisu3QeNcVOtmGml0Xw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.19"
+
+"@fortawesome/react-fontawesome@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.4.tgz#18d61d9b583ca289a61aa7dccc05bd164d6bc9ad"
+  integrity sha512-GwmxQ+TK7PEdfSwvxtGnMCqrfEm0/HbRHArbUudsYiy9KzVCwndxa2KMcfyTQ8El0vROrq8gOOff09RF1oQe8g==
+  dependencies:
+    humps "^2.0.1"
+    prop-types "^15.5.10"
+
 "@gatsbyjs/relay-compiler@2.0.0-printer-fix.2":
   version "2.0.0-printer-fix.2"
   resolved "https://registry.yarnpkg.com/@gatsbyjs/relay-compiler/-/relay-compiler-2.0.0-printer-fix.2.tgz#214db0e6072d40ea78ad5fabdb49d56bc95f4e99"
@@ -7365,6 +7399,11 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+  integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
 
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"


### PR DESCRIPTION
* Closes #57 - assumes Mastodon input is a URL and not the shorthand at-name-at-instance (this currently breaks speaker 231's link if the data doesn't get fixed in admin by the time you look at this)
  * Adds FontAwesome 5's solid and brand SVGs as dependencies (yes, for just three icons)
* Fixes schedule bleeding off the right edge on small (iPhone SE) screens by removing the `min-width`
  * Caveat: all boxes are `max-width`'d at `16rem`; removing this will make them `width: 100%`.  Revisit this next year when we make an _actual_ grid.

Includes bonus "please stop that eslint" fixes.