### PR TITLE
Replace Date + strftime w/ moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "react": "^16.2.0",
     "react-dom": "^16.4.1",
     "react-helmet": "^5.2.0",
-    "strftime": "^0.10.0",
     "uuid": "^3.2.1"
   },
   "keywords": [

--- a/src/templates/presentation-page.js
+++ b/src/templates/presentation-page.js
@@ -5,7 +5,7 @@ import { graphql, Link } from 'gatsby'
 import Img from "gatsby-image"
 import Layout from '../components/Layout'
 import Content, { HTMLContent } from '../components/Content'
-import strftime from 'strftime'
+import moment from 'moment'
 
 export const PresentationPageTemplate = ({ 
   abstract,
@@ -90,10 +90,10 @@ const PresentationPage = ({ data }) => {
 
   let startDate = "date TBD"
   let startTime = "time TBD"
-  const startDatetime = new Date(presentation.schedule.start)
-  if ( !isNaN(startDatetime) ) {
-    startDate = strftime("%a, %B %d", startDatetime)
-    startTime = strftime("%-I:%M%P", startDatetime)
+  const startMoment = moment(presentation.schedule.start)
+  if ( !isNaN(startMoment) ) {
+    startDate = startMoment.format('dddd, MMMM DD')
+    startTime = startMoment.format('h:mma')
   }
   const speakersString = presentation.speakers.map(speaker => speaker.name).join(", ")
   const pageTitle = `PyOhio 2019 Presentation: ${presentation.title}`

--- a/src/templates/schedule-page.js
+++ b/src/templates/schedule-page.js
@@ -4,7 +4,7 @@ import Helmet from "react-helmet"
 import Layout from "../components/Layout"
 import ScheduleSlot from "../components/ScheduleSlot"
 import _ from 'lodash'
-import strftime from 'strftime'
+import moment from 'moment'
 
 export default class SlottedSchedule extends React.Component {
   render() {
@@ -21,30 +21,15 @@ export default class SlottedSchedule extends React.Component {
     slots.map(slot => slot.span = `${slot.start}-${slot.end}`)
     const daySlots = _.groupBy(slots, "day")
 
-    // TODO: refactor this! Move to a utility (component?) file and use from there
-    function formatDatetime(timeString, format) {
-      let formatted = ""
-      const datetime = new Date(timeString)
-      if (!isNaN(datetime)) {
-        formatted = strftime(format, datetime)
-      }
-      return formatted
-    }
-
     function formatDate(timeString) {
-      return formatDatetime(timeString, "%A, %B %d")
+      return moment(timeString).format('dddd, MMMM DD')
     }
     function formatTime(timeString) {
-      return formatDatetime(timeString, "%-I:%M%P")
+      return moment(timeString).format('h:mma')
     }
 
     function stringToID(timeString) {
-      let formatted = ""
-      const datetime = new Date(timeString)
-      if (!isNaN(datetime)) {
-        formatted = strftime('%s', datetime)
-      }
-      return formatted
+      return moment(timeString).format('X')
     }
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -13702,11 +13702,6 @@ stream-to@~0.2.0:
   resolved "https://registry.yarnpkg.com/stream-to/-/stream-to-0.2.2.tgz#84306098d85fdb990b9fa300b1b3ccf55e8ef01d"
   integrity sha1-hDBgmNhf25kLn6MAsbPM9V6O8B0=
 
-strftime@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/strftime/-/strftime-0.10.0.tgz#b3f0fa419295202a5a289f6d6be9f4909a617193"
-  integrity sha1-s/D6QZKVICpaKJ9ta+n0kJphcZM=
-
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"


### PR DESCRIPTION
Use Moment.js instead of Date + strftime to ensure date parsing / formatting is consistent across browsers.

Tested in Safari, Chrome, and Firefox

Resolves #59 