### PR TITLE
Add temporary 2021 speaker info page

### DIFF
--- a/netlify-static/2021/present/speaker-info/index.html
+++ b/netlify-static/2021/present/speaker-info/index.html
@@ -79,7 +79,7 @@
 <p>You may review last years' talks for examples:</p>
 <ul>
 <li><a href="https://www.pyohio.org/2020/events/talks/">2020 Talks Listing</a></li>
-<li><a href=""></a>2020 Videos</li>
+<li><a href="https://www.youtube.com/playlist?list=PL2k6bbM_wgjtGSzPXzUzP3AfVO-o4imbB"></a>2020 Videos</li>
 <li><a href="https://www.pyohio.org/2019/schedule/talks/list/">2019 Talks</a></li>
 <li><a href="https://www.pyohio.org/2019/schedule/tutorials/list/">2019 Tutorials</a></li>
 </ul>

--- a/netlify-static/2021/present/speaker-info/index.html
+++ b/netlify-static/2021/present/speaker-info/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+      crossorigin="anonymous"
+    />
+    <title>PyOhio 2021 - Speaker Information</title>
+  </head>
+  <body>
+    <div class="jumbotron text-center">
+      <div class="card text-left mx-auto" style="max-width: 60rem;">
+        <div class="card-body">
+          <h1>PyOhio 2021 Speaker Information</h1>
+         
+          <h2 id="video-recording-guidelines">Video Recording Guidelines</h2>
+<p>Congratulations again on having your talk accepted for PyOhio 2021! We’re truly thankful to have you as part of this unusual year of our conference.</p>
+<p>This year, we are asking all speakers to deliver a prerecorded video of their talks. This doc will walk you through the essentials.</p>
+<h3 id="how-long-should-my-video-be">How long should my video be?</h3>
+<p>For PyOhio 2021, we are doing a collection of short talks. To help keep the event on track and running smoothly for all of our remote attendees, we have tighter time requirements than in live events:</p>
+<ul>
+<li><p><strong>Lightning Talks</strong> should be between <strong>4 - 5 minutes</strong> in length.</p></li>
+<li><p><strong>Thunder Talks</strong> should be between <strong>9 - 10 minutes</strong> in length.</p></li>
+</ul>
+<p>Please, please, please do not go over the maximum time for your talk! If you go over time, we cannot guarantee that the entire talk will be presented on the stream.</p>
+<h3 id="what-format-should-my-video-be">What format should my video be?</h3>
+<ul>
+<li>Format: H264 MP4</li>
+<li>Resolution: 1920x1080</li>
+<li>Frame rate: 30fps</li>
+</ul>
+<h3 id="when-does-my-video-have-to-be-delivered-by">When does my video have to be delivered by?</h3>
+<p>We would like to receive all videos by <strong>23:59:59 EDT on Sunday, July 18</strong>. This will give us enough time to pre-screen and process them.</p>
+<p><strong>If it looks like you will not be able to make that date, please contact us at <a href="mailto:program@pyohio.org" class="email">program@pyohio.org</a></strong> as soon as possible to let us know! This will help keep the program chair’s panic level under control. :-)</p>
+<h3 id="how-should-i-deliver-my-video">How should I deliver my video?</h3>
+<p>You have two choices for delivering your video:</p>
+<ol type="1">
+<li><strong>Upload your video to the private Dropbox folder that will be created for you</strong> (we’ll contact everyone separately by email with the link to this folder)</li>
+<li><strong>Upload your video to your own cloud sharing service</strong> and send a link to or share it with <strong><a href="mailto:program@pyohio.org" class="email">program@pyohio.org</a></strong>; we’ll handle downloading it from there.</li>
+</ol>
+<h3 id="how-should-i-record-my-presentation">How should I record my presentation?</h3>
+<p>There are lots of ways you might choose to record your presentation. Here are some suggestions that we hope will be useful. Ultimately, whatever path you choose will be fine as long as you can deliver a video in the right format.</p>
+<h4 id="recording-with-obs-studio">Recording with OBS Studio</h4>
+<p>OBS Studio is a free, open-source tool used for capturing audio and video; it runs on Mac OS, Windows, and Linux: <a href="https://obsproject.com" class="uri">https://obsproject.com</a></p>
+<p>Here’s a guide to capturing both your screen and webcam using OBS: <a href="https://www.youtube.com/watch?v=uL8BwstqiqE" class="uri">https://www.youtube.com/watch?v=uL8BwstqiqE</a></p>
+<h4 id="recording-with-screenshot.app">Recording with Screenshot.app</h4>
+<p>Mac OS 10.15 can record videos of the screen with the Screenshot app. Here’s a guide to recording your screen with a voiceover in Mac OS 10.15 / Catalina: <a href="https://www.youtube.com/watch?v=6nn86t9955Y" class="uri">https://www.youtube.com/watch?v=6nn86t9955Y</a></p>
+<h4 id="recording-with-keynote">Recording with Keynote</h4>
+<p>Apple’s Keynote can create videos with voiceover narration. Here’s a guide to creating a video with voiceover narration using just Keynote: <a href="https://www.youtube.com/watch?v=C6e2ZtHnimA" class="uri">https://www.youtube.com/watch?v=C6e2ZtHnimA</a></p>
+<p>Here’s a guide to creating a video with Keynote and combining it with a webcam recording in iMovie: <a href="https://www.youtube.com/watch?v=yRnANp2kS3c" class="uri">https://www.youtube.com/watch?v=yRnANp2kS3c</a></p>
+<h4 id="recording-with-powerpoint">Recording with PowerPoint</h4>
+<p>PowerPoint can also create videos of presentations, optionally including video from a webcam. Here’s a guide to creating a video with PowerPoint: <a href="https://www.youtube.com/watch?v=pHXRuJEsN7M" class="uri">https://www.youtube.com/watch?v=pHXRuJEsN7M</a></p>
+<h4 id="other-tools">Other Tools</h4>
+<p>Other tools you might choose include Elgato and Camtasia. If you have recommendations to share with other presenters, let us know and we’ll update this list.</p>
+<h3 id="advice">Advice</h3>
+<p>This is going to be a new and different experience for many speakers. Thank you for your courage! Here are some thoughts we’ve had that might be helpful as you prepare your video.</p>
+<h4 id="practice-first">Practice First</h4>
+<p>We <strong>strongly recommend</strong> that whatever path you take for recording, you should <strong>practice recording before doing your presentation “for real”</strong>. This way you can get comfortable with your choice of tools.</p>
+<h4 id="have-a-script">Have a Script</h4>
+<p>Have solid notes or a script that you can read from as you record your presentation. It can be a lot harder to be impromptu or to ad lib for a recording than it is to do so in a live room. Having a script of some kind will help prevent you from stumbling or freezing up (things your program chair is prone to do whenever doing voiceover work).</p>
+<h4 id="maybe-record-in-segments">Maybe Record in Segments</h4>
+<p>Delivering your presentation to a computer can feel quite different from speaking to a roomful of live attendees. You may find it valuable to record your presentation in shorter segments and assemble them using your favorite video editor.</p>
+<h4 id="live-coding-beware-keyboard-sounds">Live Coding? Beware Keyboard Sounds!</h4>
+<p>If you are live coding, using your computer’s built-in microphone may pick up the sound of typing, which can be distracting for your audience. We recommend using an external microphone or headset, or using an external keyboard. <strong>Please review the audio of your recording before submitting it!</strong></p>
+<h3 id="speakers">Speakers</h3>
+<p>PyOhio is dedicated to featuring a diverse and inclusive speaker lineup.</p>
+<p><strong>All speakers will be expected to have read and adhere to the conference <a href="/code-of-conduct">Code of Conduct</a>. In particular for speakers: slide contents and spoken material should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate, and neither are language or imagery that denigrate or demean people based on race, gender, religion, sexual orientation, physical appearance, disability, or body size.</strong></p>
+<p>We will make every effort to provide accommodations for speakers and attendees of all abilities—all we ask is that you let us know so we can prepare accordingly.</p>
+<p>PyOhio is a conference in support of the local programmer community. We aim to feature a mix of local and non-local speakers to offer a program with broad appeal.</p>
+<h3 id="resources">Resources</h3>
+<p>This <a href="https://github.com/vmbrasseur/Public_Speaking">public speaking repository</a>, maintained by <a href="https://twitter.com/vmbrasseur">VM Brasseur</a>, has many useful resources to help you polish your proposals and talks.</p>
+<p>You may review last years' talks for examples:</p>
+<ul>
+<li><a href="https://www.pyohio.org/2020/events/talks/">2020 Talks Listing</a></li>
+<li><a href=""></a>2020 Videos</li>
+<li><a href="https://www.pyohio.org/2019/schedule/talks/list/">2019 Talks</a></li>
+<li><a href="https://www.pyohio.org/2019/schedule/tutorials/list/">2019 Tutorials</a></li>
+</ul>
+<h3 id="questions">Questions?</h3>
+<p>Email us at <a href="mailto:program@pyohio.org">program@pyohio.org</a>.</p>
+
+
+        </div>
+      </div>
+    </div>
+    <div class="text-center">
+      <p>
+        <a href="https://www.netlify.com">
+          <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" />
+        </a>
+      </p>
+    </div>
+  </body>
+
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Event",
+      "name": "PyOhio 2021",
+      "startDate": "2021-07-31T10:00-05:00",
+      "location": {
+        "@type": "VirtualLocation",
+        "name": "PyOhio Online",
+        "url": "https://www.pyohio.org/",
+        "logo": "https://www.pyohio.org/2021/pyohio.jpg"
+      },
+      "image": ["https://www.pyohio.org/2021/pyohio.jpg"],
+      "description": "The FREE Python community conference. July 31, 2021.",
+      "endDate": "2021-07-31T17:00-05:00",
+      "eventAttendanceMode": "OnlineEventAttendanceMode",
+      "offers": {
+        "@type": "Offer",
+        "url": "https://www.pyohio.org/2021/",
+        "price": "0",
+        "priceCurrency": "USD",
+        "availability": "https://schema.org/InStock",
+        "validFrom": "2021-03-10T09:00-05:00"
+      }
+    }
+  </script>
+</html>

--- a/netlify-static/2021/present/speaker-info/index.html
+++ b/netlify-static/2021/present/speaker-info/index.html
@@ -26,8 +26,8 @@
 <h3 id="how-long-should-my-video-be">How long should my video be?</h3>
 <p>For PyOhio 2021, we are doing a collection of short talks. To help keep the event on track and running smoothly for all of our remote attendees, we have tighter time requirements than in live events:</p>
 <ul>
-<li><p><strong>Lightning Talks</strong> should be between <strong>4 - 5 minutes</strong> in length.</p></li>
-<li><p><strong>Thunder Talks</strong> should be between <strong>9 - 10 minutes</strong> in length.</p></li>
+<li><p><strong>Lightning Talks</strong> should be <strong>5 minutes ± 30 seconds</strong> in length.</p></li>
+<li><p><strong>Thunder Talks</strong> should be <strong>10 minutes ± 30 seconds</strong> in length.</p></li>
 </ul>
 <p>Please, please, please do not go over the maximum time for your talk! If you go over time, we cannot guarantee that the entire talk will be presented on the stream.</p>
 <h3 id="what-format-should-my-video-be">What format should my video be?</h3>

--- a/netlify-static/2021/present/speaker-info/index.html
+++ b/netlify-static/2021/present/speaker-info/index.html
@@ -80,8 +80,8 @@
 <ul>
 <li><a href="https://www.pyohio.org/2020/events/talks/">2020 Talks Listing</a></li>
 <li><a href="https://www.youtube.com/playlist?list=PL2k6bbM_wgjtGSzPXzUzP3AfVO-o4imbB">2020 Videos</a></li>
-<li><a href="https://www.pyohio.org/2019/schedule/talks/list/">2019 Talks</a></li>
-<li><a href="https://www.pyohio.org/2019/schedule/tutorials/list/">2019 Tutorials</a></li>
+<li><a href="https://www.pyohio.org/2019/events/talks/">2019 Talks</a></li>
+<li><a href="https://www.pyohio.org/2019/events/tutorials/">2019 Tutorials</a></li>
 </ul>
 <h3 id="questions">Questions?</h3>
 <p>Email us at <a href="mailto:program@pyohio.org">program@pyohio.org</a>.</p>

--- a/netlify-static/2021/present/speaker-info/index.html
+++ b/netlify-static/2021/present/speaker-info/index.html
@@ -35,6 +35,7 @@
 <li>Format: H264 MP4</li>
 <li>Resolution: 1920x1080</li>
 <li>Frame rate: 30fps</li>
+<li>Audio: AAC (preferred) or MP3</li>
 </ul>
 <h3 id="when-does-my-video-have-to-be-delivered-by">When does my video have to be delivered by?</h3>
 <p>We would like to receive all videos by <strong>23:59:59 EDT on Sunday, July 18</strong>. This will give us enough time to pre-screen and process them.</p>

--- a/netlify-static/2021/present/speaker-info/index.html
+++ b/netlify-static/2021/present/speaker-info/index.html
@@ -79,7 +79,7 @@
 <p>You may review last years' talks for examples:</p>
 <ul>
 <li><a href="https://www.pyohio.org/2020/events/talks/">2020 Talks Listing</a></li>
-<li><a href="https://www.youtube.com/playlist?list=PL2k6bbM_wgjtGSzPXzUzP3AfVO-o4imbB"></a>2020 Videos</li>
+<li><a href="https://www.youtube.com/playlist?list=PL2k6bbM_wgjtGSzPXzUzP3AfVO-o4imbB">2020 Videos</a></li>
 <li><a href="https://www.pyohio.org/2019/schedule/talks/list/">2019 Talks</a></li>
 <li><a href="https://www.pyohio.org/2019/schedule/tutorials/list/">2019 Tutorials</a></li>
 </ul>


### PR DESCRIPTION
Add a temporary copy of the speaker info page so we can provide a working link to confirmed speakers.

The new version of the full site will be available Soon and this page will exist at the same URL.