### PR TITLE
Fix social image header links

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -4,6 +4,7 @@ import { useSiteMetadata, SocialFooter } from "gatsby-theme-catalyst-core"
 import { IconContext } from "react-icons"
 import { useFooterConfig } from "gatsby-theme-catalyst-footer/src/utils/use-footer-config"
 import { StaticImage } from "gatsby-plugin-image"
+import { Helmet } from "react-helmet"
 
 const SiteFooter = () => {
   const { title } = useSiteMetadata()
@@ -29,6 +30,16 @@ const SiteFooter = () => {
         variant: "variants.footer",
       }}
     >
+      <Helmet>
+        <meta
+          property="og:image"
+          content="https://www.pyohio.org/pyohio-2021-logo-og.jpg"
+        />
+        <meta
+          name="twitter:image"
+          content="https://www.pyohio.org/pyohio-2021-logo-og.jpg"
+        />
+      </Helmet>
       <div
         sx={{
           display: "grid",

--- a/src/templates/speaker-page.js
+++ b/src/templates/speaker-page.js
@@ -17,21 +17,21 @@ export default function TalkPage({ data }) {
 
   return (
     <Layout>
-    <BaseStyles>
-      <h1>{speaker.name}</h1>
-      <Themed.img
-        as={GatsbyImage}
-        sx={{
-          borderRadius: "35px",
-          border: "7px solid",
-          borderColor: "highlight",
-        }}
-        image={getImage(speaker.localImage.childImageSharp)}
-      />
-      <div dangerouslySetInnerHTML={{ __html: speaker.biography }} />
-      <h2>Presenting</h2>
-      <p>{talks}</p>
-    </BaseStyles>
+      <BaseStyles>
+        <h1>{speaker.name}</h1>
+        <Themed.img
+          as={GatsbyImage}
+          sx={{
+            borderRadius: "35px",
+            border: "7px solid",
+            borderColor: "highlight",
+          }}
+          image={getImage(speaker.localImage.childImageSharp)}
+        />
+        <div dangerouslySetInnerHTML={{ __html: speaker.biography }} />
+        <h2>Presenting</h2>
+        <p>{talks}</p>
+      </BaseStyles>
     </Layout>
   )
 }

--- a/src/templates/talk-page.js
+++ b/src/templates/talk-page.js
@@ -16,15 +16,15 @@ export default function TalkPage({ data }) {
 
   return (
     <Layout>
-    <BaseStyles>
-      <h1>{talk.title}</h1>
-      <p>
-        <em>{talk.type} (schedule TBD)</em>
-      </p>
-      <div dangerouslySetInnerHTML={{ __html: talk.description }} />
-      <h2>Presented by</h2>
-      <p>{speakers}</p>
-    </BaseStyles>
+      <BaseStyles>
+        <h1>{talk.title}</h1>
+        <p>
+          <em>{talk.type} (schedule TBD)</em>
+        </p>
+        <div dangerouslySetInnerHTML={{ __html: talk.description }} />
+        <h2>Presented by</h2>
+        <p>{speakers}</p>
+      </BaseStyles>
     </Layout>
   )
 }


### PR DESCRIPTION
The base theme doesn't seem to account for the site's `pathPrefix` so this uses react-helmet to override the URLs w/ a direct one for now.