### PR TITLE
Restore changes to speaker info page from pre-launch version

### DIFF
--- a/content/pages/speaking/speaker-info.mdx
+++ b/content/pages/speaking/speaker-info.mdx
@@ -17,9 +17,9 @@ For PyOhio 2021, we are doing a collection of short talks. To help keep
 the event on track and running smoothly for all of our remote attendees,
 we have tighter time requirements than in live events:
 
-- **Lightning Talks** should be between **4 - 5 minutes** in length.
+- **Lightning Talks** should be **5 minutes ± 30 seconds** in length.
 
-- **Thunder Talks** should be between **9 - 10 minutes** in length.
+- **Thunder Talks** should be **10 minutes ± 30 seconds** in length.
 
 Please, please, please do not go over the maximum time for your talk! If
 you go over time, we cannot guarantee that the entire talk will be
@@ -30,6 +30,7 @@ presented on the stream.
 - Format: H264 MP4
 - Resolution: 1920x1080
 - Frame rate: 30fps
+- Audio: AAC (preferred) or MP3
 
 ### When does my video have to be delivered by?
 


### PR DESCRIPTION
These changes had been made to the pre-launch website but not to the core site.