### PR TITLE
Speaker info updates

### DIFF
--- a/content/pages/speaking/speaker-info.mdx
+++ b/content/pages/speaking/speaker-info.mdx
@@ -17,9 +17,9 @@ For PyOhio 2022, we are doing a collection of short talks. To help keep
 the event on track and running smoothly for all of our remote attendees,
 we have tighter time requirements than in live events:
 
-- **Lightning Talks** should be **5 minutes ± 30 seconds** in length.
+- **Short Talks** should be between **10 - 15 minutes** in length.
 
-- **Thunder Talks** should be **10 minutes ± 30 seconds** in length.
+- **Shorter Talks** should be **5 minutes ± 30 seconds** in length.
 
 Please, please, please do not go over the maximum time for your talk! If
 you go over time, we cannot guarantee that the entire talk will be
@@ -27,15 +27,18 @@ presented on the stream.
 
 ### What format should my video be?
 
-- Format: H264 MP4
+- Format: H264 MP4 (.mp4 or .m4v please)
 - Resolution: 1920x1080
 - Frame rate: 30fps
 - Audio: AAC (preferred) or MP3
 
+Please **do not submit your video in .mkv format**,
+it just makes extra work for us to prepare it for streaming.
+
 ### When does my video have to be delivered by?
 
 We would like to receive all videos by **23:59:59 EDT on Sunday, July
-18**. This will give us enough time to pre-screen and process them.
+17**. This will give us enough time to pre-screen and process them.
 
 **If it looks like you will not be able to make that date, please
 contact us at <program@pyohio.org>** as soon as possible to let us know!
@@ -69,7 +72,7 @@ Here's a guide to capturing both your screen and webcam using OBS:
 
 #### Recording with Screenshot.app
 
-Mac OS 10.15 can record videos of the screen with the Screenshot app.
+Mac OS 10.15+ can record videos of the screen with the Screenshot app.
 Here's a guide to recording your screen with a voiceover in Mac OS 10.15
 / Catalina: <https://www.youtube.com/watch?v=6nn86t9955Y>
 
@@ -88,6 +91,18 @@ webcam recording in iMovie:
 PowerPoint can also create videos of presentations, optionally including
 video from a webcam. Here's a guide to creating a video with PowerPoint:
 <https://www.youtube.com/watch?v=pHXRuJEsN7M>
+
+#### Recording with Loom
+
+Loom lets you record your camera, microphone, and desktop simultaneously.
+Videos are limited to a maximum of 5 minutes in the free tier,
+but the paid tier allows for recordings of unlimited length.
+If you use Loom or a service like it,
+we request that you not share the video prior to the conference.
+Instead, please download it and deliver it to us using the instructions above.
+
+Here's how to get started:
+<https://support.loom.com/hc/en-us/categories/360000251678-Getting-Started>
 
 #### Other Tools
 
@@ -130,6 +145,16 @@ We recommend using an external microphone or headset, or using an
 external keyboard. **Please review the audio of your recording before
 submitting it!**
 
+#### Audio Quality
+
+Please be careful with your audio, as it can be a make-or-break aspect
+of a remote presentation. If your audio levels are too high, it can
+cause clipping, a distortion effect that is highly uncomfortable for
+listeners and which is very difficult for us to repair. **It's better for
+your video to be a little quiet than for it to be too loud** -- we can
+always bump the levels up when we normalize all the audio to prepare
+it for streaming!
+
 ### Speakers
 
 PyOhio is dedicated to featuring a diverse and inclusive speaker lineup.
@@ -142,6 +167,10 @@ Sexual language and imagery is not appropriate, and neither are language
 or imagery that denigrate or demean people based on race, gender,
 religion, sexual orientation, physical appearance, disability, or body
 size.**
+
+PyOhio does not tolerate plagiarism. Speakers' presentations must be
+their own, original material, with appropriate citations when incorporating
+the work of others.
 
 We will make every effort to provide accommodations for speakers and
 attendees of all abilities---all we ask is that you let us know so we


### PR DESCRIPTION
Various updates to the speaker info page for 2022:

- Updated talk length guidelines.
- Updated video format guidelines.
- Updated video due date.
- Added note about Loom.
- Added advice about audio quality.
- Added note about originality of speaker presentations/no plagiarism please.

We will need this to land before I can send out the speaker info email blast.