### PR TITLE
Fix “Health & Safety” page title ampersand rendering

### DIFF
--- a/2025/src/pages/about/health-and-safety.md
+++ b/2025/src/pages/about/health-and-safety.md
@@ -1,5 +1,5 @@
 ---
-title: 'Health &amp; Safety'
+title: 'Health & Safety'
 layout: '../../layouts/MarkdownLayout.astro'
 ---
 


### PR DESCRIPTION
Hello! 👋

I was checking out the website and noticed that my favorite page has a title rendering issue:

<img width="214" alt="image" src="https://github.com/user-attachments/assets/a7a0c4cf-a09e-4cb6-9d14-42e0c79af297" />

With this fix it looks better:

<img width="214" alt="image" src="https://github.com/user-attachments/assets/2b0d97ce-fbb5-4d29-8415-f7d2dedc59b7" />

---

Caveat: I’m not super familiar with any of the tooling, so there may be a better way of solving this, like a template tag that would avoid escaping and render HTML entities. An example would be `safe` [in Django](https://docs.djangoproject.com/en/5.2/ref/templates/builtins/#safe). But the above works too. 😁